### PR TITLE
Allow to use multiple kernels in a single test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ deptrac: vendor/bin/deptrac
 .PHONY: deptrac
 
 infection: vendor/bin/infection vendor/bin/infection.pubkey
-	phpdbg -qrr ./vendor/bin/infection --no-interaction --formatter=progress --min-msi=87 --min-covered-msi=89 --ansi
+	phpdbg -qrr ./vendor/bin/infection --no-interaction --formatter=progress --min-msi=89 --min-covered-msi=91 --ansi
 .PHONY: infection
 
 phpunit: vendor/bin/phpunit

--- a/depfile.yml
+++ b/depfile.yml
@@ -72,7 +72,6 @@ ruleset:
     - TestCase
     - Symfony DependencyInjection
   Symfony TestCase:
-    - Symfony Compiler
     - Psr Container
     - Symfony DependencyInjection
     - Symfony HttpKernel

--- a/src/Symfony/Compiler/ExposeServicesForTestsPass.php
+++ b/src/Symfony/Compiler/ExposeServicesForTestsPass.php
@@ -5,6 +5,7 @@ namespace Zalas\Injector\PHPUnit\Symfony\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Zalas\Injector\PHPUnit\Symfony\Compiler\Discovery\PropertyDiscovery;
@@ -35,7 +36,7 @@ class ExposeServicesForTestsPass implements CompilerPassInterface
     private function discoverServices(): array
     {
         return \array_reduce($this->propertyDiscovery->run(), function (array $services, Property $property) {
-            $services[$property->getClassName()][$property->getServiceId()] = new Reference($property->getServiceId());
+            $services[$property->getClassName()][$property->getServiceId()] = new Reference($property->getServiceId(), ContainerInterface::IGNORE_ON_INVALID_REFERENCE);
 
             return $services;
         }, []);

--- a/src/Symfony/Compiler/ExposeServicesForTestsPass.php
+++ b/src/Symfony/Compiler/ExposeServicesForTestsPass.php
@@ -12,44 +12,32 @@ use Zalas\Injector\Service\Property;
 
 class ExposeServicesForTestsPass implements CompilerPassInterface
 {
-    const DEFAULT_SERVICE_LOCATOR_ID = 'app.test.service_locator';
-
-    /**
-     * @var string
-     */
-    private $serviceLocatorId;
-
     /**
      * @var PropertyDiscovery
      */
     private $propertyDiscovery;
 
-    public function __construct(string $serviceLocatorId = self::DEFAULT_SERVICE_LOCATOR_ID, ?PropertyDiscovery $propertyDiscovery = null)
+    public function __construct(?PropertyDiscovery $propertyDiscovery = null)
     {
-        $this->serviceLocatorId = $serviceLocatorId;
         $this->propertyDiscovery = $propertyDiscovery ?? new PropertyDiscovery();
     }
 
     public function process(ContainerBuilder $container): void
     {
-        $container->register($this->serviceLocatorId, ServiceLocator::class)
-            ->setPublic(true)
-            ->addTag('container.service_locator')
-            ->addArgument($this->discoverServices());
+        foreach ($this->discoverServices() as $testClass => $references) {
+            $container->register($testClass, ServiceLocator::class)
+                ->setPublic(true)
+                ->addTag('container.service_locator')
+                ->addArgument($references);
+        }
     }
 
     private function discoverServices(): array
     {
-        return $this->flatMap(
-            function (Property $property) {
-                return [$property->getServiceId() => new Reference($property->getServiceId())];
-            },
-            $this->propertyDiscovery->run()
-        );
-    }
+        return \array_reduce($this->propertyDiscovery->run(), function (array $services, Property $property) {
+            $services[$property->getClassName()][$property->getServiceId()] = new Reference($property->getServiceId());
 
-    private function flatMap(callable $callback, array $collection): array
-    {
-        return \array_merge([], ...\array_map($callback, $collection));
+            return $services;
+        }, []);
     }
 }

--- a/src/Symfony/TestCase/SymfonyContainer.php
+++ b/src/Symfony/TestCase/SymfonyContainer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Zalas\Injector\PHPUnit\Symfony\TestCase;
 
 use Psr\Container\ContainerInterface;
-use Zalas\Injector\PHPUnit\Symfony\Compiler\ExposeServicesForTestsPass;
 
 /**
  * Provides a `ServiceContainerTestCase` implementation with the container created by the Symfony Kernel.
@@ -15,11 +14,6 @@ trait SymfonyContainer
 
     public function createContainer(): ContainerInterface
     {
-        return static::bootKernel()->getContainer()->get($this->getTestServiceLocatorId());
-    }
-
-    protected function getTestServiceLocatorId(): string
-    {
-        return ExposeServicesForTestsPass::DEFAULT_SERVICE_LOCATOR_ID;
+        return static::bootKernel()->getContainer()->get(__CLASS__);
     }
 }

--- a/tests/Symfony/Compiler/ExposeServicesForTestsPassTest.php
+++ b/tests/Symfony/Compiler/ExposeServicesForTestsPassTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Zalas\Injector\PHPUnit\Symfony\Compiler\Discovery\PropertyDiscovery;
@@ -58,12 +59,12 @@ class ExposeServicesForTestsPassTest extends TestCase
         $this->assertFalse($container->getDefinition(TestCase1::class)->isPrivate(), 'The first test case service locator is registered as a public service.');
         $this->assertTrue($container->getDefinition(TestCase1::class)->isPublic(), 'The first test case service locator is registered as a public service.');
         $this->assertTrue($container->getDefinition(TestCase1::class)->hasTag('container.service_locator'), 'The first case service locator is tagged.');
-        $this->assertEquals([Service1::class => new Reference(Service1::class), Service2::class => new Reference(Service2::class)], $container->getDefinition(TestCase1::class)->getArgument(0));
+        $this->assertEquals([Service1::class => new Reference(Service1::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE), Service2::class => new Reference(Service2::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)], $container->getDefinition(TestCase1::class)->getArgument(0));
         $this->assertTrue($container->hasDefinition(TestCase2::class), 'The second test case service locator is registered as a service.');
         $this->assertFalse($container->getDefinition(TestCase2::class)->isPrivate(), 'The second test case service locator is registered as a public service.');
         $this->assertTrue($container->getDefinition(TestCase2::class)->isPublic(), 'The second test case service locator is registered as a public service.');
         $this->assertTrue($container->getDefinition(TestCase2::class)->hasTag('container.service_locator'), 'The second test case service locator is tagged.');
-        $this->assertEquals([Service2::class => new Reference(Service2::class)], $container->getDefinition(TestCase2::class)->getArgument(0));
+        $this->assertEquals([Service2::class => new Reference(Service2::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)], $container->getDefinition(TestCase2::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)->getArgument(0));
     }
 
     public function test_it_only_registers_a_service_locator_if_any_services_were_discovered()

--- a/tests/Symfony/Compiler/ExposeServicesForTestsPassTest.php
+++ b/tests/Symfony/Compiler/ExposeServicesForTestsPassTest.php
@@ -14,12 +14,11 @@ use Zalas\Injector\PHPUnit\Symfony\Compiler\ExposeServicesForTestsPass;
 use Zalas\Injector\PHPUnit\Tests\Symfony\Compiler\Fixtures\Service1;
 use Zalas\Injector\PHPUnit\Tests\Symfony\Compiler\Fixtures\Service2;
 use Zalas\Injector\PHPUnit\Tests\Symfony\Compiler\Fixtures\TestCase1;
+use Zalas\Injector\PHPUnit\Tests\Symfony\Compiler\Fixtures\TestCase2;
 use Zalas\Injector\Service\Property;
 
 class ExposeServicesForTestsPassTest extends TestCase
 {
-    const SERVICE_LOCATOR_ID = 'app.test.service_locator';
-
     /**
      * @var ExposeServicesForTestsPass
      */
@@ -33,7 +32,7 @@ class ExposeServicesForTestsPassTest extends TestCase
     protected function setUp()
     {
         $this->discovery = $this->prophesize(PropertyDiscovery::class);
-        $this->pass = new ExposeServicesForTestsPass(self::SERVICE_LOCATOR_ID, $this->discovery->reveal());
+        $this->pass = new ExposeServicesForTestsPass($this->discovery->reveal());
     }
 
     public function test_it_is_a_compiler_pass()
@@ -41,26 +40,33 @@ class ExposeServicesForTestsPassTest extends TestCase
         $this->assertInstanceOf(CompilerPassInterface::class, $this->pass);
     }
 
-    public function test_it_registers_a_service_locator_for_services_used_in_tests()
+    public function test_it_registers_a_service_locator_for_each_test_case_requiring_service_injection()
     {
         $this->discovery->run()->willReturn([
             new Property(TestCase1::class, 'service1', Service1::class),
             new Property(TestCase1::class, 'service2', Service2::class),
+            new Property(TestCase2::class, 'service2', Service2::class),
         ]);
 
         $container = new ContainerBuilder();
 
         $this->pass->process($container);
 
-        $this->assertTrue($container->hasDefinition(self::SERVICE_LOCATOR_ID), 'The service locator is registered as a service.');
-        $this->assertSame(ServiceLocator::class, $container->getDefinition(self::SERVICE_LOCATOR_ID)->getClass());
-        $this->assertFalse($container->getDefinition(self::SERVICE_LOCATOR_ID)->isPrivate(), 'The service locator is registered as a public service.');
-        $this->assertTrue($container->getDefinition(self::SERVICE_LOCATOR_ID)->isPublic(), 'The service locator is registered as a public service.');
-        $this->assertTrue($container->getDefinition(self::SERVICE_LOCATOR_ID)->hasTag('container.service_locator'), 'The service locator is tagged.');
-        $this->assertEquals([Service1::class => new Reference(Service1::class), Service2::class => new Reference(Service2::class)], $container->getDefinition(self::SERVICE_LOCATOR_ID)->getArgument(0));
+        $this->assertTrue($container->hasDefinition(TestCase1::class), 'The first test case service locator is registered as a service.');
+        $this->assertSame(ServiceLocator::class, $container->getDefinition(TestCase1::class)->getClass());
+        $this->assertSame(ServiceLocator::class, $container->getDefinition(TestCase2::class)->getClass());
+        $this->assertFalse($container->getDefinition(TestCase1::class)->isPrivate(), 'The first test case service locator is registered as a public service.');
+        $this->assertTrue($container->getDefinition(TestCase1::class)->isPublic(), 'The first test case service locator is registered as a public service.');
+        $this->assertTrue($container->getDefinition(TestCase1::class)->hasTag('container.service_locator'), 'The first case service locator is tagged.');
+        $this->assertEquals([Service1::class => new Reference(Service1::class), Service2::class => new Reference(Service2::class)], $container->getDefinition(TestCase1::class)->getArgument(0));
+        $this->assertTrue($container->hasDefinition(TestCase2::class), 'The second test case service locator is registered as a service.');
+        $this->assertFalse($container->getDefinition(TestCase2::class)->isPrivate(), 'The second test case service locator is registered as a public service.');
+        $this->assertTrue($container->getDefinition(TestCase2::class)->isPublic(), 'The second test case service locator is registered as a public service.');
+        $this->assertTrue($container->getDefinition(TestCase2::class)->hasTag('container.service_locator'), 'The second test case service locator is tagged.');
+        $this->assertEquals([Service2::class => new Reference(Service2::class)], $container->getDefinition(TestCase2::class)->getArgument(0));
     }
 
-    public function test_it_registers_an_empty_service_locator_if_no_services_were_discovered()
+    public function test_it_only_registers_a_service_locator_if_any_services_were_discovered()
     {
         $this->discovery->run()->willReturn([]);
 
@@ -68,7 +74,7 @@ class ExposeServicesForTestsPassTest extends TestCase
 
         $this->pass->process($container);
 
-        $this->assertTrue($container->hasDefinition(self::SERVICE_LOCATOR_ID), 'The service locator is registered as a service.');
-        $this->assertEquals([], $container->getDefinition(self::SERVICE_LOCATOR_ID)->getArgument(0), 'No services were registered on the service locator.');
+        $this->assertfalse($container->hasDefinition(TestCase1::class), 'The first test case service locator is not registered as a service.');
+        $this->assertfalse($container->hasDefinition(TestCase2::class), 'The second test case service locator is not registered as a service.');
     }
 }

--- a/tests/Symfony/TestCase/Fixtures/AnotherTestKernel.php
+++ b/tests/Symfony/TestCase/Fixtures/AnotherTestKernel.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Zalas\Injector\PHPUnit\Symfony\Compiler\Discovery\ClassFinder;
+use Zalas\Injector\PHPUnit\Symfony\Compiler\Discovery\PropertyDiscovery;
+use Zalas\Injector\PHPUnit\Symfony\Compiler\ExposeServicesForTestsPass;
+
+class AnotherTestKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        return [];
+    }
+
+    public function getCacheDir()
+    {
+        return \sys_get_temp_dir().'/ZalasPHPUnitInjector2/cache/'.$this->environment;
+    }
+
+    public function getLogDir()
+    {
+        return \sys_get_temp_dir().'/ZalasPHPUnitInjector2/logs';
+    }
+
+    /**
+     * Loads the container configuration.
+     */
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) use ($loader) {
+            $container->register(Service1::class, Service1::class);
+        });
+    }
+
+    protected function build(ContainerBuilder $container)
+    {
+        if ('test' === $this->getEnvironment()) {
+            $container->addCompilerPass(
+                new ExposeServicesForTestsPass(
+                    new PropertyDiscovery(new ClassFinder(__DIR__ . '/../'))
+                )
+            );
+        }
+    }
+}

--- a/tests/Symfony/TestCase/Fixtures/TestKernel.php
+++ b/tests/Symfony/TestCase/Fixtures/TestKernel.php
@@ -43,7 +43,6 @@ class TestKernel extends Kernel
         if ('test' === $this->getEnvironment()) {
             $container->addCompilerPass(
                 new ExposeServicesForTestsPass(
-                    ExposeServicesForTestsPass::DEFAULT_SERVICE_LOCATOR_ID,
                     new PropertyDiscovery(new ClassFinder(__DIR__ . '/../'))
                 )
             );

--- a/tests/Symfony/TestCase/SymfonyContainerTest.php
+++ b/tests/Symfony/TestCase/SymfonyContainerTest.php
@@ -9,7 +9,6 @@ use Zalas\Injector\PHPUnit\Symfony\TestCase\SymfonyContainer;
 use Zalas\Injector\PHPUnit\TestCase\ServiceContainerTestCase;
 use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\Service1;
 use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\Service2;
-use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel;
 
 class SymfonyContainerTest extends TestCase implements ServiceContainerTestCase
 {
@@ -27,6 +26,9 @@ class SymfonyContainerTest extends TestCase implements ServiceContainerTestCase
      */
     private $service2;
 
+    /**
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel
+     */
     public function test_it_initializes_the_container_by_booting_the_symfony_kernel()
     {
         $container = $this->createContainer();
@@ -38,8 +40,16 @@ class SymfonyContainerTest extends TestCase implements ServiceContainerTestCase
         $this->assertInstanceOf(Service2::class, $container->get('foo.service2'));
     }
 
-    protected static function getKernelClass()
+    /**
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\AnotherTestKernel
+     */
+    public function test_it_ignores_missing_services_when_registering_the_service_locator()
     {
-        return TestKernel::class;
+        $container = $this->createContainer();
+
+        $this->assertInstanceOf(ServiceLocator::class, $container, 'Full container is not exposed.');
+        $this->assertTrue($container->has(Service1::class), 'The private service is available in tests.');
+        $this->assertFalse($container->has('foo.service2'), 'The private service is available in tests.');
+        $this->assertInstanceOf(Service1::class, $container->get(Service1::class));
     }
 }


### PR DESCRIPTION
The limitation is we still can't use different kernels within the same test case class. All services defined in the test case need to be available for all tests in the test case.