### PR TITLE
Refresh the container when a test case changes

### DIFF
--- a/depfile.yml
+++ b/depfile.yml
@@ -30,6 +30,10 @@ layers:
     collectors:
       - type: className
         regex: ^Psr\\Container\\.*
+  - name: Symfony Config
+    collectors:
+      - type: className
+        regex: ^Symfony\\Component\\Config\\.*
   - name: Symfony DependencyInjection
     collectors:
       - type: className
@@ -62,6 +66,8 @@ layers:
           - type: className
             regex: ^PHPUnit\\Framework\\.*
           - type: className
+            regex: ^Symfony\\Component\\Config\\.*
+          - type: className
             regex: ^Symfony\\Component\\DependencyInjection\\.*
           - type: className
             regex: ^Symfony\\Component\\HttpKernel\\.*
@@ -70,6 +76,7 @@ ruleset:
     - Injector Factory
     - Injector Service
     - TestCase
+    - Symfony Config
     - Symfony DependencyInjection
   Symfony TestCase:
     - Psr Container

--- a/src/Symfony/Compiler/ExposeServicesForTestsPass.php
+++ b/src/Symfony/Compiler/ExposeServicesForTestsPass.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Zalas\Injector\PHPUnit\Symfony\Compiler;
 
+use Symfony\Component\Config\Resource\ReflectionClassResource;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -30,6 +31,8 @@ class ExposeServicesForTestsPass implements CompilerPassInterface
                 ->setPublic(true)
                 ->addTag('container.service_locator')
                 ->addArgument($references);
+
+            $container->addResource(new ReflectionClassResource(new \ReflectionClass($testClass)));
         }
     }
 


### PR DESCRIPTION
Otherwise adding a new service dependency to a test case will raise an exception that the service does not exist (since it was inlined).
