### PR TITLE
Add support for the test service container from Symfony 4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ deptrac: vendor/bin/deptrac
 .PHONY: deptrac
 
 infection: vendor/bin/infection vendor/bin/infection.pubkey
-	phpdbg -qrr ./vendor/bin/infection --no-interaction --formatter=progress --min-msi=89 --min-covered-msi=91 --ansi
+	phpdbg -qrr ./vendor/bin/infection --no-interaction --formatter=progress --min-msi=91 --min-covered-msi=91 --only-covered --ansi
 .PHONY: infection
 
 phpunit: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "symfony/config": "^3.4 || ^4.0",
         "symfony/dependency-injection": "^3.4 || ^4.0",
         "symfony/http-kernel": "^3.4 || ^4.0",
-        "zalas/phpunit-globals": "^1.0"
+        "zalas/phpunit-globals": "^1.0",
+        "symfony/framework-bundle": "^3.4||^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Symfony/Compiler/ExposeServicesForTestsPass.php
+++ b/src/Symfony/Compiler/ExposeServicesForTestsPass.php
@@ -12,6 +12,9 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 use Zalas\Injector\PHPUnit\Symfony\Compiler\Discovery\PropertyDiscovery;
 use Zalas\Injector\Service\Property;
 
+/**
+ * Looks for `@inject` annotations to register services in test service locators and make them available in tests.
+ */
 class ExposeServicesForTestsPass implements CompilerPassInterface
 {
     /**

--- a/src/Symfony/TestCase/SymfonyContainer.php
+++ b/src/Symfony/TestCase/SymfonyContainer.php
@@ -7,6 +7,8 @@ use Psr\Container\ContainerInterface;
 
 /**
  * Provides a `ServiceContainerTestCase` implementation with the container created by the Symfony Kernel.
+ *
+ * Relies on `ExposeServicesForTestsPass` compiler pass being registered.
  */
 trait SymfonyContainer
 {

--- a/src/Symfony/TestCase/SymfonyTestContainer.php
+++ b/src/Symfony/TestCase/SymfonyTestContainer.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\Injector\PHPUnit\Symfony\TestCase;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Provides a `ServiceContainerTestCase` implementation with the test container from the Symfony FrameworkBundle.
+ *
+ * `framework.test` needs to be set to `true` in order for the `test.service_container` to be available.
+ */
+trait SymfonyTestContainer
+{
+    use SymfonyKernel;
+
+    public function createContainer(): ContainerInterface
+    {
+        return static::bootKernel()->getContainer()->get('test.service_container');
+    }
+}

--- a/tests/Symfony/TestCase/Fixtures/FrameworkBundle/AnotherTestKernel.php
+++ b/tests/Symfony/TestCase/Fixtures/FrameworkBundle/AnotherTestKernel.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\FrameworkBundle;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\Kernel;
+use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\Service1;
+
+class AnotherTestKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        return [
+            new FrameworkBundle(),
+        ];
+    }
+
+    public function getCacheDir()
+    {
+        return \sys_get_temp_dir().'/ZalasPHPUnitInjector/FrameworkBundle/AnotherTestKernel/cache/'.$this->environment;
+    }
+
+    public function getLogDir()
+    {
+        return \sys_get_temp_dir().'/ZalasPHPUnitInjector/FrameworkBundle/AnotherTestKernel/logs';
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) use ($loader) {
+            $container->register(Service1::class, Service1::class);
+
+            $container->register('public_service', \stdClass::class)
+                ->setPublic(true)
+                ->setArguments([
+                    new Reference(Service1::class)
+                ]);
+
+            $container->loadFromExtension('framework', ['test' => true]);
+            $container->setParameter('kernel.secret', '$ecre7');
+        });
+    }
+}

--- a/tests/Symfony/TestCase/Fixtures/FrameworkBundle/TestKernel.php
+++ b/tests/Symfony/TestCase/Fixtures/FrameworkBundle/TestKernel.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\FrameworkBundle;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\Kernel;
+use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\Service1;
+use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\Service2;
+
+class TestKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        return [
+            new FrameworkBundle(),
+        ];
+    }
+
+    public function getCacheDir()
+    {
+        return \sys_get_temp_dir().'/ZalasPHPUnitInjector/FrameworkBundle/TestKernel/cache/'.$this->environment;
+    }
+
+    public function getLogDir()
+    {
+        return \sys_get_temp_dir().'/ZalasPHPUnitInjector/FrameworkBundle/TestKernel/logs';
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) use ($loader) {
+            $container->register(Service1::class, Service1::class);
+            $container->register('foo.service2', Service2::class);
+            $container->register('public_service', \stdClass::class)
+                ->setPublic(true)
+                ->setArguments([
+                    new Reference(Service1::class),
+                    new Reference('foo.service2')
+                ]);
+
+            $container->loadFromExtension('framework', ['test' => true]);
+            $container->setParameter('kernel.secret', '$ecre7');
+        });
+    }
+}

--- a/tests/Symfony/TestCase/Fixtures/NoFrameworkBundle/AnotherTestKernel.php
+++ b/tests/Symfony/TestCase/Fixtures/NoFrameworkBundle/AnotherTestKernel.php
@@ -1,16 +1,18 @@
 <?php
 declare(strict_types=1);
 
-namespace Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures;
+namespace Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Kernel;
 use Zalas\Injector\PHPUnit\Symfony\Compiler\Discovery\ClassFinder;
 use Zalas\Injector\PHPUnit\Symfony\Compiler\Discovery\PropertyDiscovery;
 use Zalas\Injector\PHPUnit\Symfony\Compiler\ExposeServicesForTestsPass;
+use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\Service1;
 
-class TestKernel extends Kernel
+class AnotherTestKernel extends Kernel
 {
     public function registerBundles()
     {
@@ -19,22 +21,18 @@ class TestKernel extends Kernel
 
     public function getCacheDir()
     {
-        return \sys_get_temp_dir().'/ZalasPHPUnitInjector/cache/'.$this->environment;
+        return \sys_get_temp_dir().'/ZalasPHPUnitInjector/NoFrameworkBundle/AnotherTestKernel/cache/'.$this->environment;
     }
 
     public function getLogDir()
     {
-        return \sys_get_temp_dir().'/ZalasPHPUnitInjector/logs';
+        return \sys_get_temp_dir().'/ZalasPHPUnitInjector/NoFrameworkBundle/AnotherTestKernel/logs';
     }
 
-    /**
-     * Loads the container configuration.
-     */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $loader->load(function (ContainerBuilder $container) use ($loader) {
             $container->register(Service1::class, Service1::class);
-            $container->register('foo.service2', Service2::class);
         });
     }
 
@@ -43,7 +41,7 @@ class TestKernel extends Kernel
         if ('test' === $this->getEnvironment()) {
             $container->addCompilerPass(
                 new ExposeServicesForTestsPass(
-                    new PropertyDiscovery(new ClassFinder(__DIR__ . '/../'))
+                    new PropertyDiscovery(new ClassFinder(__DIR__ . '/../../'))
                 )
             );
         }

--- a/tests/Symfony/TestCase/Fixtures/NoFrameworkBundle/TestKernel.php
+++ b/tests/Symfony/TestCase/Fixtures/NoFrameworkBundle/TestKernel.php
@@ -1,16 +1,19 @@
 <?php
 declare(strict_types=1);
 
-namespace Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures;
+namespace Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Kernel;
 use Zalas\Injector\PHPUnit\Symfony\Compiler\Discovery\ClassFinder;
 use Zalas\Injector\PHPUnit\Symfony\Compiler\Discovery\PropertyDiscovery;
 use Zalas\Injector\PHPUnit\Symfony\Compiler\ExposeServicesForTestsPass;
+use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\Service1;
+use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\Service2;
 
-class AnotherTestKernel extends Kernel
+class TestKernel extends Kernel
 {
     public function registerBundles()
     {
@@ -19,21 +22,19 @@ class AnotherTestKernel extends Kernel
 
     public function getCacheDir()
     {
-        return \sys_get_temp_dir().'/ZalasPHPUnitInjector2/cache/'.$this->environment;
+        return \sys_get_temp_dir().'/ZalasPHPUnitInjector/NoFrameworkBundle/TestKernel/cache/'.$this->environment;
     }
 
     public function getLogDir()
     {
-        return \sys_get_temp_dir().'/ZalasPHPUnitInjector2/logs';
+        return \sys_get_temp_dir().'/ZalasPHPUnitInjector/NoFrameworkBundle/TestKernel/logs';
     }
 
-    /**
-     * Loads the container configuration.
-     */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $loader->load(function (ContainerBuilder $container) use ($loader) {
             $container->register(Service1::class, Service1::class);
+            $container->register('foo.service2', Service2::class);
         });
     }
 
@@ -42,7 +43,7 @@ class AnotherTestKernel extends Kernel
         if ('test' === $this->getEnvironment()) {
             $container->addCompilerPass(
                 new ExposeServicesForTestsPass(
-                    new PropertyDiscovery(new ClassFinder(__DIR__ . '/../'))
+                    new PropertyDiscovery(new ClassFinder(__DIR__ . '/../../'))
                 )
             );
         }

--- a/tests/Symfony/TestCase/SymfonyContainerTest.php
+++ b/tests/Symfony/TestCase/SymfonyContainerTest.php
@@ -27,7 +27,7 @@ class SymfonyContainerTest extends TestCase implements ServiceContainerTestCase
     private $service2;
 
     /**
-     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle\TestKernel
      */
     public function test_it_initializes_the_container_by_booting_the_symfony_kernel()
     {
@@ -41,7 +41,7 @@ class SymfonyContainerTest extends TestCase implements ServiceContainerTestCase
     }
 
     /**
-     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\AnotherTestKernel
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle\AnotherTestKernel
      */
     public function test_it_ignores_missing_services_when_registering_the_service_locator()
     {
@@ -49,7 +49,7 @@ class SymfonyContainerTest extends TestCase implements ServiceContainerTestCase
 
         $this->assertInstanceOf(ServiceLocator::class, $container, 'Full container is not exposed.');
         $this->assertTrue($container->has(Service1::class), 'The private service is available in tests.');
-        $this->assertFalse($container->has('foo.service2'), 'The private service is available in tests.');
+        $this->assertFalse($container->has('foo.service2'), 'The private service is not available in tests.');
         $this->assertInstanceOf(Service1::class, $container->get(Service1::class));
     }
 }

--- a/tests/Symfony/TestCase/SymfonyKernelTest.php
+++ b/tests/Symfony/TestCase/SymfonyKernelTest.php
@@ -6,7 +6,7 @@ namespace Zalas\Injector\PHPUnit\Tests\Symfony\TestCase;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Zalas\Injector\PHPUnit\Symfony\TestCase\SymfonyKernel;
-use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel;
+use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle\TestKernel;
 
 class SymfonyKernelTest extends TestCase
 {
@@ -20,7 +20,7 @@ class SymfonyKernelTest extends TestCase
     }
 
     /**
-     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle\TestKernel
      */
     public function test_it_boots_the_kernel_in_test_environment_with_debug_enabled_by_default()
     {
@@ -33,7 +33,7 @@ class SymfonyKernelTest extends TestCase
     }
 
     /**
-     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle\TestKernel
      * @env APP_ENV=test_foo
      * @env APP_DEBUG=0
      */
@@ -48,7 +48,7 @@ class SymfonyKernelTest extends TestCase
     }
 
     /**
-     * @server KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel
+     * @server KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle\TestKernel
      * @server APP_ENV=test_foo
      * @server APP_DEBUG=0
      */
@@ -98,7 +98,7 @@ class SymfonyKernelTest extends TestCase
     }
 
     /**
-     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle\TestKernel
      * @env APP_ENV=test_foo
      * @env APP_DEBUG=0
      * @server KERNEL_CLASS=Bar
@@ -115,7 +115,7 @@ class SymfonyKernelTest extends TestCase
     }
 
     /**
-     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle\TestKernel
      */
     public function test_it_ensures_the_kernel_was_shut_down()
     {
@@ -127,7 +127,7 @@ class SymfonyKernelTest extends TestCase
     }
 
     /**
-     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle\TestKernel
      */
     public function test_ensureKernelShutdown_shuts_down_the_kernel()
     {
@@ -139,7 +139,7 @@ class SymfonyKernelTest extends TestCase
     }
 
     /**
-     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle\TestKernel
      */
     public function test_ensureKernelShutdown_resets_the_container()
     {
@@ -158,7 +158,7 @@ class SymfonyKernelTest extends TestCase
     }
 
     /**
-     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle\TestKernel
      */
     public function test_it_creates_the_kernel_in_test_environment_with_debug_enabled_by_default()
     {
@@ -170,7 +170,7 @@ class SymfonyKernelTest extends TestCase
     }
 
     /**
-     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle\TestKernel
      * @env APP_ENV=test_foo
      * @env APP_DEBUG=0
      */
@@ -184,7 +184,7 @@ class SymfonyKernelTest extends TestCase
     }
 
     /**
-     * @server KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\TestKernel
+     * @server KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\NoFrameworkBundle\TestKernel
      * @server APP_ENV=test_foo
      * @server APP_DEBUG=0
      */

--- a/tests/Symfony/TestCase/SymfonyTestContainerTest.php
+++ b/tests/Symfony/TestCase/SymfonyTestContainerTest.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\Injector\PHPUnit\Tests\Symfony\TestCase;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\TestContainer;
+use Zalas\Injector\PHPUnit\Symfony\TestCase\SymfonyTestContainer;
+use Zalas\Injector\PHPUnit\TestCase\ServiceContainerTestCase;
+use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\Service1;
+use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\Service2;
+
+class SymfonyTestContainerTest extends TestCase implements ServiceContainerTestCase
+{
+    use SymfonyTestContainer;
+
+    protected function setUp()
+    {
+        if (!\class_exists(TestContainer::class)) {
+            $this->markTestSkipped('SymfonyTestContainer requires Symfony >= 4.1.');
+        }
+    }
+
+    /**
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\FrameworkBundle\TestKernel
+     */
+    public function test_it_initializes_the_container_by_booting_the_symfony_kernel()
+    {
+        $container = $this->createContainer();
+
+        $this->assertInstanceOf(TestContainer::class, $container, 'Full container is not exposed.');
+        $this->assertTrue($container->has(Service1::class), 'The private service is available in tests.');
+        $this->assertTrue($container->has('foo.service2'), 'The private service is available in tests.');
+        $this->assertInstanceOf(Service1::class, $container->get(Service1::class));
+        $this->assertInstanceOf(Service2::class, $container->get('foo.service2'));
+    }
+
+    /**
+     * @env KERNEL_CLASS=Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\FrameworkBundle\AnotherTestKernel
+     */
+    public function test_it_ignores_missing_services_when_registering_the_service_locator()
+    {
+        $container = $this->createContainer();
+
+        $this->assertInstanceOf(TestContainer::class, $container, 'Full container is not exposed.');
+        $this->assertTrue($container->has(Service1::class), 'The private service is available in tests.');
+        $this->assertFalse($container->has('foo.service2'), 'The private service is not available in tests.');
+        $this->assertInstanceOf(Service1::class, $container->get(Service1::class));
+    }
+}


### PR DESCRIPTION
The `Zalas\Injector\PHPUnit\Symfony\TestCase\SymfonyTestContainer` trait provides
access to the test container ([introduced in Symfony 4.1](https://symfony.com/blog/new-in-symfony-4-1-simpler-service-testing)).

Including the trait in a test case implementing the `ServiceContainerTestCase` will make that services are injected into annotated properties:

```php
use PHPUnit\Framework\TestCase;
use Psr\Log\LoggerInterface;
use Symfony\Component\Serializer\SerializerInterface;
use Zalas\Injector\PHPUnit\Symfony\TestCase\SymfonyTestContainer;
use Zalas\Injector\PHPUnit\TestCase\ServiceContainerTestCase;

class ServiceInjectorTest extends TestCase implements ServiceContainerTestCase
{
    use SymfonyTestContainer;

    /**
     * @var SerializerInterface
     * @inject
     */
    private $serializer;

    /**
     * @var LoggerInterface
     * @inject logger
     */
    private $logger;

    public function testThatServicesAreInjected()
    {
        $this->assertInstanceOf(SerializerInterface::class, $this->serializer, 'The service is injectd by its type');
        $this->assertInstanceOf(LoggerInterface::class, $this->logger, 'The service is injected by its id');
    }
}
```