### PR TITLE
Fix an issue with traits referencing class constants

### DIFF
--- a/src/Symfony/Compiler/Discovery/ClassFinder.php
+++ b/src/Symfony/Compiler/Discovery/ClassFinder.php
@@ -56,13 +56,13 @@ class ClassFinder
             if (!\is_array($tokens[$index])) {
                 continue;
             }
-            if (T_NAMESPACE === $tokens[$index][0]) {
+            if ($this->isNamespaceToken($tokens, $index)) {
                 $index += 2; // Skip namespace keyword and whitespace
                 while (isset($tokens[$index]) && \is_array($tokens[$index]) && T_WHITESPACE !== $tokens[$index][0]) {
                     $namespace .= $tokens[$index++][1];
                 }
             }
-            if (T_CLASS === $tokens[$index][0]) {
+            if ($this->isClassDefinitionToken($tokens, $index)) {
                 $index += 2; // Skip class keyword and whitespace
                 $class = $namespace . '\\' . $tokens[$index][1];
                 if ($predicate($class)) {
@@ -74,6 +74,16 @@ class ClassFinder
         }
 
         return $classes;
+    }
+
+    private function isNamespaceToken($tokens, int $index): bool
+    {
+        return T_NAMESPACE === $tokens[$index][0];
+    }
+
+    private function isClassDefinitionToken($tokens, int $index): bool
+    {
+        return T_CLASS === $tokens[$index][0] && T_WHITESPACE === $tokens[$index + 1][0] && T_STRING === $tokens[$index + 2][0];
     }
 
     /**

--- a/tests/Symfony/Compiler/Fixtures/FooTrait.php
+++ b/tests/Symfony/Compiler/Fixtures/FooTrait.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\Injector\PHPUnit\Tests\Symfony\Compiler\Fixtures;
+
+trait FooTrait
+{
+    /**
+     * Reproduces https://github.com/jakzal/phpunit-injector/issues/3
+     */
+    protected function bar(): string
+    {
+        return Service1::class;
+    }
+}


### PR DESCRIPTION
Solves an issue when a trait references a class constant which is then wrongly treated as a class definition:

```
class_implements(): Class Zalas\Injector\PHPUnit\Tests\Symfony\Compiler\Fixtures\
     does not exist and could not be loaded
```

Fixes #3