### PR TITLE
Scope dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,4 @@
 /phpunit.xml.dist export-ignore
 /tests export-ignore
 /tools export-ignore
+/scoper.inc.php export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 - if [[ $deps = low ]]; then make update-min; else make install; fi
 script:
 - if [[ $deps = low ]]; then make test-min; else make test; fi
-- make package
+- make package test-package
 deploy:
   provider: releases
   api_key:

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ test: vendor cs deptrac phpunit infection
 test-min: update-min cs deptrac phpunit infection
 .PHONY: test-min
 
+test-package: package test-package-tools
+	cd tests/phar && ./tools/phpunit
+.PHONY: test-package
+
 cs: tools/php-cs-fixer
 	tools/php-cs-fixer --dry-run --allow-risky=yes --no-interaction --ansi fix
 .PHONY: cs
@@ -48,8 +52,14 @@ phpunit: tools/phpunit
 tools: tools/php-cs-fixer tools/deptrac tools/infection tools/box
 .PHONY: tools
 
+test-package-tools: tests/phar/tools/phpunit tests/phar/tools/phpunit.d/zalas-phpunit-injector-extension.phar
+.PHONY: test-package-tools
+
 clean:
 	rm -rf build
+	rm -rf vendor
+	find tools -not -path '*/\.*' -type f -delete
+	find tests/phar/tools -not -path '*/\.*' -type f -delete
 .PHONY: clean
 
 package: tools/box
@@ -90,3 +100,11 @@ tools/infection.pubkey:
 
 tools/box:
 	curl -Ls https://github.com/humbug/box/releases/download/3.0.0-beta.4/box.phar -o tools/box && chmod +x tools/box
+
+tests/phar/tools/phpunit:
+	curl -Ls https://phar.phpunit.de/phpunit-7.phar -o tests/phar/tools/phpunit && chmod +x tests/phar/tools/phpunit
+
+tests/phar/tools/phpunit.d/zalas-phpunit-injector-extension.phar: build/zalas-phpunit-injector-extension.phar
+	cp build/zalas-phpunit-injector-extension.phar tests/phar/tools/phpunit.d/zalas-phpunit-injector-extension.phar
+
+build/zalas-phpunit-injector-extension.phar: package

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ package: tools/box
 	$(eval VERSION=$(shell git describe --abbrev=0 --tags 2> /dev/null | sed -e 's/^v//' || echo 'dev'))
 	@rm -rf build/phar && mkdir -p build/phar
 
-	cp -r src LICENSE composer.json build/phar
+	cp -r src LICENSE composer.json scoper.inc.php build/phar
 	sed -e 's/@@version@@/$(VERSION)/g' manifest.xml.in > build/phar/manifest.xml
 
 	cd build/phar && \
@@ -89,4 +89,4 @@ tools/infection.pubkey:
 	curl -Ls https://github.com/infection/infection/releases/download/0.9.0/infection.phar.pubkey -o tools/infection.pubkey
 
 tools/box:
-	curl -Ls https://github.com/humbug/box/releases/download/3.0.0-beta.0/box.phar -o tools/box && chmod +x tools/box
+	curl -Ls https://github.com/humbug/box/releases/download/3.0.0-beta.4/box.phar -o tools/box && chmod +x tools/box

--- a/box.json.dist
+++ b/box.json.dist
@@ -7,6 +7,9 @@
     "exclude-composer-files": true,
     "check-requirements": false,
     "main": "vendor/autoload.php",
+    "compactors": [
+        "KevinGH\\Box\\Compactor\\PhpScoper"
+    ],
     "banner": [
         "This file is part of the zalas/phpunit-injector project.",
         "",

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+return [
+    'whitelist' => [
+        'Psr\Container\*',
+        'PHPUnit\Framework\*',
+        'Symfony\Component\*',
+        'Zalas\Injector\*',
+    ],
+];

--- a/tests/phar/phpunit.xml
+++ b/tests/phar/phpunit.xml
@@ -1,21 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.2/phpunit.xsd"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
-         colors="true"
-         verbose="true">
-
+         verbose="true"
+         extensionsDirectory="tools/phpunit.d">
     <testsuites>
         <testsuite name="default">
             <directory suffix="Test.php">tests</directory>
-            <exclude>tests/phar</exclude>
         </testsuite>
     </testsuites>
 
     <listeners>
-        <listener class="Zalas\PHPUnit\Globals\AnnotationListener" />
+        <listener class="Zalas\Injector\PHPUnit\TestListener\ServiceInjectorListener" />
     </listeners>
 
     <filter>
@@ -23,9 +20,4 @@
             <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
-
-    <logging>
-        <log type="coverage-html" target="build/coverage" lowUpperBound="50" highLowerBound="95"/>
-        <log type="coverage-clover" target="build/coverage.xml"/>
-    </logging>
 </phpunit>

--- a/tests/phar/tests/PharTest.php
+++ b/tests/phar/tests/PharTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Zalas\Injector\PHPUnit\TestCase\ServiceContainerTestCase;
+
+class PharTest extends TestCase implements ServiceContainerTestCase
+{
+    /**
+     * @var stdClass
+     * @inject foo.service
+     */
+    private $service;
+
+    public function test_it_injects_services_into_test_cases()
+    {
+        $this->assertInstanceOf(stdClass::class, $this->service);
+    }
+
+    public function createContainer(): ContainerInterface
+    {
+        return new class implements ContainerInterface {
+            public function get($id)
+            {
+                if ('foo.service' === $id) {
+                    return new stdClass();
+                }
+
+                throw new class extends \Exception implements NotFoundExceptionInterface {
+                };
+            }
+
+            public function has($id)
+            {
+                return \in_array($id, ['foo.service'], true);
+            }
+        };
+    }
+}

--- a/tests/phar/tools/.gitignore
+++ b/tests/phar/tools/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/phar/tools/phpunit.d/.gitignore
+++ b/tests/phar/tools/phpunit.d/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Only phpDocumentor and webmozart/assert packages can be effectively scoped. All other dependencies need to be unchaged for the client.

Fixes #12
