### PR TITLE
Ignore the base phpunit test case during property extraction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^7.2",
         "phpunit/phpunit": "^8.0",
         "psr/container": "^1.0",
-        "zalas/injector": "^1.0"
+        "zalas/injector": "^1.2"
     },
     "require-dev": {
         "symfony/config": "^3.4 || ^4.0",

--- a/depfile.yml
+++ b/depfile.yml
@@ -75,6 +75,7 @@ ruleset:
   Symfony Compiler:
     - Injector Factory
     - Injector Service
+    - PHPUnit
     - TestCase
     - Symfony Config
     - Symfony DependencyInjection

--- a/src/Symfony/Compiler/Discovery/PropertyDiscovery.php
+++ b/src/Symfony/Compiler/Discovery/PropertyDiscovery.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Zalas\Injector\PHPUnit\Symfony\Compiler\Discovery;
 
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
 use Zalas\Injector\Factory\DefaultExtractorFactory;
 use Zalas\Injector\PHPUnit\TestCase\ServiceContainerTestCase;
 use Zalas\Injector\Service\ExtractorFactory;
@@ -23,7 +25,7 @@ class PropertyDiscovery
     public function __construct(?ClassFinder $classFinder = null, ?ExtractorFactory $extractorFactory = null)
     {
         $this->classFinder = $classFinder ?? new ClassFinder();
-        $this->extractorFactory = $extractorFactory ?? new DefaultExtractorFactory();
+        $this->extractorFactory = $extractorFactory ?? new DefaultExtractorFactory([TestCase::class, Assert::class]);
     }
 
     /**

--- a/src/TestListener/ServiceInjectorListener.php
+++ b/src/TestListener/ServiceInjectorListener.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace Zalas\Injector\PHPUnit\TestListener;
 
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestListenerDefaultImplementation;
 use Zalas\Injector\Factory\DefaultExtractorFactory;
@@ -17,7 +19,7 @@ class ServiceInjectorListener implements TestListener
     public function startTest(Test $test): void
     {
         if ($test instanceof ServiceContainerTestCase) {
-            $injector = new Injector(new TestCaseContainerFactory($test), new DefaultExtractorFactory());
+            $injector = new Injector(new TestCaseContainerFactory($test), new DefaultExtractorFactory([TestCase::class, Assert::class]));
             $injector->inject($test);
         }
     }


### PR DESCRIPTION
To workaround [problems with the reflectiondocblock](https://github.com/phpDocumentor/ReflectionDocBlock/issues/173) and possibly improve performance.

[Before](https://travis-ci.org/jakzal/phpunit-injector/jobs/542438743#L575): ~500ms

<img width="587" alt="image" src="https://user-images.githubusercontent.com/190447/59144199-fa2b0300-89cb-11e9-88d1-47af81cdb4d2.png">

[After](https://travis-ci.org/jakzal/phpunit-injector/jobs/543075995#L576): ~220ms

<img width="586" alt="image" src="https://user-images.githubusercontent.com/190447/59144202-0ca53c80-89cc-11e9-8066-17196a824675.png">
