### PR TITLE
Remove typehint for KernelInterface to make it compatible with Symfony

### DIFF
--- a/src/Symfony/TestCase/SymfonyKernel.php
+++ b/src/Symfony/TestCase/SymfonyKernel.php
@@ -12,7 +12,10 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 trait SymfonyKernel
 {
-    protected static ?KernelInterface $kernel = null;
+    /**
+     * @var KernelInterface|null
+     */
+    protected static $kernel = null;
 
     protected static function bootKernel(array $options = []): KernelInterface
     {


### PR DESCRIPTION
This is a fix for an issue mentioned in #30

