### PR TITLE
Update PHP version constraint in manifest

### DIFF
--- a/manifest.xml.in
+++ b/manifest.xml.in
@@ -10,6 +10,6 @@
     </copyright>
 
     <requires>
-        <php version="^7.4"/>
+        <php version="^7.4 || ^8.0"/>
     </requires>
 </phar>


### PR DESCRIPTION
Hi,

This PR is meant to fix the following warning we get with Phive:

```
# phive install jakzal/phpunit-injector --force-accept-unsigned
Phive 0.14.4 - Copyright (C) 2015-2022 by Arne Blankerts, Sebastian Heuer and Contributors
Downloading https://api.github.com/rate_limit
Downloading https://github.com/jakzal/phpunit-injector/releases/download/v2.1.0/zalas-phpunit-injector-extension.phar
[WARNING]  Your environment does not seem to satisfy the needs this phar has:

           PHP Version ^7.4 required, but 8.0.12 in use

Install anyway? [y|N]
```

