### PR TITLE
Allow psr/container 2.0 and Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,15 +5,15 @@
     "require": {
         "php": "~8.0.0 || ~8.1.0",
         "phpunit/phpunit": "^9.0",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0 || ^2.0",
         "zalas/injector": "^2.0"
     },
     "require-dev": {
-        "symfony/config": "^4.4.12 || ^5.3",
-        "symfony/dependency-injection": "^4.4.12 || ^5.3",
-        "symfony/http-kernel": "^4.4.12 || ^5.3",
+        "symfony/config": "^4.4.12 || ^5.3 || ^6.0",
+        "symfony/dependency-injection": "^4.4.12 || ^5.3 || ^6.0",
+        "symfony/http-kernel": "^4.4.12 || ^5.3 || ^6.0",
         "zalas/phpunit-globals": "^2.0",
-        "symfony/framework-bundle": "^4.4.12 || ^5.3",
+        "symfony/framework-bundle": "^4.4.12 || ^5.3 || ^6.0",
         "zalas/phpunit-doubles": "^1.5",
         "phpspec/prophecy": "^1.9",
         "phpspec/prophecy-phpunit": "^2.0"

--- a/tests/Symfony/TestCase/Fixtures/FrameworkBundle/AnotherTestKernel.php
+++ b/tests/Symfony/TestCase/Fixtures/FrameworkBundle/AnotherTestKernel.php
@@ -12,19 +12,19 @@ use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\Service1;
 
 class AnotherTestKernel extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return [
             new FrameworkBundle(),
         ];
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return \sys_get_temp_dir().'/ZalasPHPUnitInjector/FrameworkBundle/AnotherTestKernel/cache/'.$this->environment;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return \sys_get_temp_dir().'/ZalasPHPUnitInjector/FrameworkBundle/AnotherTestKernel/logs';
     }

--- a/tests/Symfony/TestCase/Fixtures/FrameworkBundle/TestKernel.php
+++ b/tests/Symfony/TestCase/Fixtures/FrameworkBundle/TestKernel.php
@@ -18,19 +18,19 @@ class TestKernel extends Kernel
         parent::__construct($environment, $debug);
     }
 
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return [
             new FrameworkBundle(),
         ];
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return \sys_get_temp_dir().'/ZalasPHPUnitInjector/FrameworkBundle/TestKernel/cache/'.$this->environment;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return \sys_get_temp_dir().'/ZalasPHPUnitInjector/FrameworkBundle/TestKernel/logs';
     }

--- a/tests/Symfony/TestCase/Fixtures/NoFrameworkBundle/AnotherTestKernel.php
+++ b/tests/Symfony/TestCase/Fixtures/NoFrameworkBundle/AnotherTestKernel.php
@@ -14,17 +14,17 @@ use Zalas\Injector\PHPUnit\Tests\Symfony\TestCase\Fixtures\Service1;
 
 class AnotherTestKernel extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return [];
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return \sys_get_temp_dir().'/ZalasPHPUnitInjector/NoFrameworkBundle/AnotherTestKernel/cache/'.$this->environment;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return \sys_get_temp_dir().'/ZalasPHPUnitInjector/NoFrameworkBundle/AnotherTestKernel/logs';
     }

--- a/tests/Symfony/TestCase/Fixtures/NoFrameworkBundle/TestKernel.php
+++ b/tests/Symfony/TestCase/Fixtures/NoFrameworkBundle/TestKernel.php
@@ -19,17 +19,17 @@ class TestKernel extends Kernel
         parent::__construct($environment, $debug);
     }
 
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return [];
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return \sys_get_temp_dir().'/ZalasPHPUnitInjector/NoFrameworkBundle/TestKernel/cache/'.$this->environment;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return \sys_get_temp_dir().'/ZalasPHPUnitInjector/NoFrameworkBundle/TestKernel/logs';
     }

--- a/tests/TestListener/ServiceInjectorListenerTest.php
+++ b/tests/TestListener/ServiceInjectorListenerTest.php
@@ -72,7 +72,7 @@ class ServiceInjectorListenerTest extends TestCase implements ServiceContainerTe
                 };
             }
 
-            public function has($id)
+            public function has($id): bool
             {
                 return \in_array($id, [Service1::class, 'foo.service2'], true);
             }

--- a/tests/phar/tests/PharTest.php
+++ b/tests/phar/tests/PharTest.php
@@ -31,7 +31,7 @@ class PharTest extends TestCase implements ServiceContainerTestCase
                 };
             }
 
-            public function has($id)
+            public function has($id): bool
             {
                 return \in_array($id, ['foo.service'], true);
             }


### PR DESCRIPTION
This was a little tricky to check since the Infection tests fail on my machine for some reason with an error: 

> The process has been signaled with signal "11".

Also, to properly test this a new release of `zalas/injector` must be released with https://github.com/jakzal/injector/pull/23 merged so we can actually install psr/container 2.0 because of transient dependencies.

