### PR TITLE
Added PHP 8.3 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,12 @@ jobs:
         name: Build and test
         strategy:
             matrix:
-                php: ['8.1', '8.2']
+                php: ['8.1', '8.2', '8.3']
                 deps: [high]
                 include:
                     -   php: '8.2'
+                        deps: low
+                    -   php: '8.3'
                         deps: low
 
         steps:

--- a/Makefile
+++ b/Makefile
@@ -104,10 +104,10 @@ tools/deptrac:
 	curl -Ls https://github.com/sensiolabs-de/deptrac/releases/download/1.0.2/deptrac.phar -o tools/deptrac && chmod +x tools/deptrac
 
 tools/infection: tools/infection.pubkey
-	curl -Ls https://github.com/infection/infection/releases/download/0.26.16/infection.phar -o tools/infection && chmod +x tools/infection
+	curl -Ls https://github.com/infection/infection/releases/download/0.26.21/infection.phar -o tools/infection && chmod +x tools/infection
 
 tools/infection.pubkey:
-	curl -Ls https://github.com/infection/infection/releases/download/0.26.16/infection.phar.pubkey -o tools/infection.pubkey
+	curl -Ls https://github.com/infection/infection/releases/download/0.26.21/infection.phar.pubkey -o tools/infection.pubkey
 
 tools/box:
 	curl -Ls https://github.com/humbug/box/releases/download/3.16.0/box.phar -o tools/box && chmod +x tools/box

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Injects services from a PSR-11 dependency injection container to PHPUnit test cases",
     "type": "library",
     "require": {
-        "php": "~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "phpunit/phpunit": "^9.0",
         "psr/container": "^1.0 || ^2.0",
         "zalas/injector": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony/http-kernel": "^4.4.12 || ^5.3 || ^6.0",
         "zalas/phpunit-globals": "^2.0",
         "symfony/framework-bundle": "^4.4.12 || ^5.3 || ^6.0",
-        "zalas/phpunit-doubles": "^1.5",
+        "zalas/phpunit-doubles": "^1.9.2",
         "phpspec/prophecy": "^1.9",
         "phpspec/prophecy-phpunit": "^2.0"
     },


### PR DESCRIPTION
- Increased version of infection tool to avoid errors
- ~dependencies in a dev build are now installed with `--ignore-platform-reqs` because dev dependency zalas/phpunit-globals requires PhpUnit 10 in a version that supports PHP 8.3.~
- tests are passing with min deps and high deps (at least locally)
- increased minimum version of dev dependency zalas/phpunit-doubles, so the minimal deps install passes tests
