### PR TITLE
add support for PHPUnit 10 and 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^9.0 || ^10.0 || ^11.0",
         "psr/container": "^1.0 || ^2.0",
         "zalas/injector": "^2.0"
     },


### PR DESCRIPTION
We are updating our dependencies in the the Shopsys Platform and PHPUnit 11 is one of them, so this is a needed change so we can make this update, thank you. I have already tested it in our stack and it is working correctly with PHPUnit 11.