### PR TITLE
Bump dependencies to allow for latest phpunit versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         "zalas/injector": "^2.0"
     },
     "require-dev": {
-        "symfony/config": "^4.4.12 || ^5.3 || ^6.0",
-        "symfony/dependency-injection": "^4.4.12 || ^5.3 || ^6.0",
-        "symfony/http-kernel": "^4.4.12 || ^5.3 || ^6.0",
+        "symfony/config": "^4.4.12 || ^5.3 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^4.4.12 || ^5.3 || ^6.0 || ^7.0",
+        "symfony/http-kernel": "^4.4.12 || ^5.3 || ^6.0 || ^7.0",
         "zalas/phpunit-globals": "^2.0 || ^3.0",
         "symfony/framework-bundle": "^4.4.12 || ^5.3 || ^6.0",
         "zalas/phpunit-doubles": "^1.9.2",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "symfony/config": "^4.4.12 || ^5.3 || ^6.0",
         "symfony/dependency-injection": "^4.4.12 || ^5.3 || ^6.0",
         "symfony/http-kernel": "^4.4.12 || ^5.3 || ^6.0",
-        "zalas/phpunit-globals": "^2.0",
+        "zalas/phpunit-globals": "^2.0 || ^3.0",
         "symfony/framework-bundle": "^4.4.12 || ^5.3 || ^6.0",
         "zalas/phpunit-doubles": "^1.9.2",
         "phpspec/prophecy": "^1.9",


### PR DESCRIPTION
Re #47 

* Allow for latest zalas/phpunit-globals
* Allow for latest symfony components