### PR TITLE
Drop PHPUnit 10 and 11 for now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-        "phpunit/phpunit": "^9.0 || ^10.0 || ^11.0",
+        "phpunit/phpunit": "^9.0",
         "psr/container": "^1.0 || ^2.0",
         "zalas/injector": "^2.0"
     },

--- a/tests/phar/phpunit.xml
+++ b/tests/phar/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          verbose="true"


### PR DESCRIPTION
It turns out it does not work due to changes in PHPUnit (missing traits like TestListenerDefaultImplementation).

Tests were not failing before as other dependencies were preventing the PHPUnit from updating to 11.

Re #47

<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

